### PR TITLE
Update authcode.php: replacing null with empty string for password

### DIFF
--- a/auth/oidc/classes/loginflow/authcode.php
+++ b/auth/oidc/classes/loginflow/authcode.php
@@ -650,7 +650,7 @@ class authcode extends base {
             }
             $username = $user->username;
             $this->updatetoken($tokenrec->id, $authparams, $tokenparams);
-            $user = authenticate_user_login($username, null, true);
+            $user = authenticate_user_login($username, '', true);
 
             if (!empty($user)) {
                 complete_user_login($user);


### PR DESCRIPTION
With Moodle 4.3 the OIDC login throws an error as the type for the password does not match.